### PR TITLE
Update clpaths variable to use SASCONFIGDIR correctly

### DIFF
--- a/fact-gathering/clean-restart-midtier-s9/collect_latest_midtier_logs_configs_s9.sh
+++ b/fact-gathering/clean-restart-midtier-s9/collect_latest_midtier_logs_configs_s9.sh
@@ -199,7 +199,7 @@ function collect_gemfire_logs() {
   # 2025-12-05 gw Need to handle instances other than ins_41415.
 
   shopt -s nullglob
-  clpaths=( "$SASCONFIGDIR/Web/*/instances/ins_*" )
+  clpaths=( "$SASCONFIGDIR"/Web/*/instances/ins_* )
   shopt -u nullglob
 
   # The clpaths array will contain all the cache locator instance paths.
@@ -223,7 +223,7 @@ function collect_gemfire_logs_all() {
   # 2025-12-05 gw Need to handle instances other than ins_41415.
 
   shopt -s nullglob
-  clpaths=( "$SASCONFIGDIR/Web/*/instances/ins_*" )
+  clpaths=( "$SASCONFIGDIR"/Web/*/instances/ins_* )
   shopt -u nullglob
 
   # The clpaths array will contain all the cache locator instance paths.


### PR DESCRIPTION
As it stands, when running the script, it captures a folder named ins_* when trying to collect the SAS Cache Locator logs.  The double quotes around the variable name is preventing the wildcards from working.  Need to adjust where the double quotes are so that the path is parsed correctly and all ins_* subfolders are collected, and not just a folder named ins_* with nothing in it.  